### PR TITLE
Introduce prefix_retain.conf to customize environment variables to keep

### DIFF
--- a/prefix_retain.conf
+++ b/prefix_retain.conf
@@ -1,0 +1,8 @@
+# The environment variables that should be kept when entering prefix 
+# Example:
+#
+# WAYLAND_DISPLAY
+# XDG_RUNTIME_DIR
+#
+# This will keep WAYLAND_DISPLAY and XDG_RUNTIME_DIR environment variables
+

--- a/startprefix
+++ b/startprefix
@@ -51,6 +51,7 @@ export SHELL
 
 # give a small notice
 echo "Starting Gentoo Prefix shell ${SHELL}"
+echo "Edit ${EPREFIX}/etc/prefix_retain.conf to add environment variables to keep"
 echo "[exit the shell to deactivate Gentoo Prefix]"
 # start the login shell, clean the entire environment but what's needed
 RETAIN="HOME=$HOME TERM=$TERM USER=$USER SHELL=$SHELL"
@@ -69,6 +70,13 @@ if [[ -d /proc/registry ]]; then # we're on Cygwin
 	# some Windows programs (e.g. devenv.exe) need TMP or TEMP
 	[[ -n ${TEMP} ]] && RETAIN+=" TEMP=$TEMP"
 fi
+
+# Load user defined RETAIN variables
+while IFS= read -r key; do
+  [[ -z "$key" || "$key" == \#* ]] && continue
+  RETAIN+=" $key=${!key}"
+done < ${EPREFIX}/etc/prefix_retain.conf
+
 # do it!
 if [[ ${SHELL#${EPREFIX}} != ${SHELL} ]] ; then
 	'@GENTOO_PORTAGE_EENV@' -i $RETAIN $SHELL -l


### PR DESCRIPTION
Many programs use environment variables, like tmux uses $TMUX, wayland
applications use $WAYLAND_DISPLAY, as well as $XAUTHORITY,
$XDG_RUNTIME_DIR, $DBUS_SESSION_BUS_ADDRESS, etc.


Bug: https://bugs.gentoo.org/915393

The ebuild should also be updated to install this configuration file